### PR TITLE
Refactor CategorySelectionViewModel to remove Redundant code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ captures/
 .idea/sonarlint
 .idea/misc.xml
 .idea/deploymentTargetDropDown.xml
+.idea/deploymentTargetSelector.xml
 .idea/workspace.xml
 .idea/tasks.xml
 .idea/gradle.xml

--- a/feature/category/src/main/kotlin/com/naveenapps/expensemanager/feature/category/selection/CategorySelectionViewModel.kt
+++ b/feature/category/src/main/kotlin/com/naveenapps/expensemanager/feature/category/selection/CategorySelectionViewModel.kt
@@ -20,25 +20,27 @@ class CategorySelectionViewModel @Inject constructor(
     private val _categories = MutableStateFlow<List<Category>>(emptyList())
     val categories = _categories.asStateFlow()
 
-    private val _selectedCategory = MutableStateFlow<List<Category>>(emptyList())
-    val selectedCategories = _selectedCategory.asStateFlow()
+    private val _selectedCategories = MutableStateFlow<List<Category>>(emptyList())
+    val selectedCategories = _selectedCategories.asStateFlow()
 
     init {
-        getCategoriesUseCase.invoke().map { categories ->
-            _categories.value = categories
-            if (_selectedCategory.value.isEmpty()) {
-                _selectedCategory.value = categories
-            }
-        }.launchIn(viewModelScope)
+        getCategoriesUseCase.invoke()
+                .map { categories ->
+                    _categories.value = categories
+                    if (_selectedCategories.value.isEmpty()) {
+                        _selectedCategories.value = categories
+                    }
+                }
+                .launchIn(viewModelScope)
     }
 
     fun clearChanges() {
-        _selectedCategory.value = emptyList()
+        _selectedCategories.value = emptyList()
     }
 
     fun selectThisCategory(category: Category, selected: Boolean) {
         viewModelScope.launch {
-            val selectedCategories = _selectedCategory.value.toMutableList()
+            val selectedCategories = _selectedCategories.value.toMutableList()
 
             val selectedCategory = selectedCategories.firstOrNull {
                 category.id == it.id
@@ -54,33 +56,17 @@ class CategorySelectionViewModel @Inject constructor(
                 }
             }
 
-            _selectedCategory.value = selectedCategories
+            _selectedCategories.value = selectedCategories
         }
     }
 
-    fun selectAllThisCategory(categories: List<Category>) {
-        if (categories.isEmpty()) {
-            return
-        }
+    fun selectAllTheseCategories(categories: List<Category>) {
+        categories.ifEmpty { return }
 
         viewModelScope.launch {
             clearChanges()
-
-            val selectedCategories = _selectedCategory.value.toMutableList()
-
-            repeat(categories.size) {
-                val category = categories[it]
-
-                val selectedCategory = selectedCategories.firstOrNull {
-                    category.id == it.id
-                }
-
-                if (selectedCategory == null) {
-                    selectedCategories.add(category)
-                }
-            }
-
-            _selectedCategory.value = selectedCategories
+            _selectedCategories.value = categories
         }
+
     }
 }

--- a/feature/category/src/main/kotlin/com/naveenapps/expensemanager/feature/category/selection/MultipleCategoriesSelectionScreen.kt
+++ b/feature/category/src/main/kotlin/com/naveenapps/expensemanager/feature/category/selection/MultipleCategoriesSelectionScreen.kt
@@ -37,7 +37,7 @@ fun MultipleCategoriesSelectionScreen(
     selectedCategories: List<Category> = emptyList(),
     onItemSelection: ((List<Category>, Boolean) -> Unit)? = null,
 ) {
-    viewModel.selectAllThisCategory(selectedCategories)
+    viewModel.selectAllTheseCategories(selectedCategories)
 
     CategorySelectionView(viewModel, onItemSelection)
 }

--- a/feature/category/src/test/java/com/naveenapps/expensemanager/feature/category/selection/CategorySelectionViewModelTest.kt
+++ b/feature/category/src/test/java/com/naveenapps/expensemanager/feature/category/selection/CategorySelectionViewModelTest.kt
@@ -97,7 +97,7 @@ class CategorySelectionViewModelTest : BaseCoroutineTest() {
             Truth.assertThat(firstItem).isNotEmpty()
             Truth.assertThat(firstItem).hasSize(5)
 
-            categorySelectionViewModel.selectAllThisCategory(getRandomCategoryData(3))
+            categorySelectionViewModel.selectAllTheseCategories(getRandomCategoryData(3))
 
             val secondItem = awaitItem()
             Truth.assertThat(secondItem).isEmpty()
@@ -117,7 +117,7 @@ class CategorySelectionViewModelTest : BaseCoroutineTest() {
             Truth.assertThat(firstItem).isNotEmpty()
             Truth.assertThat(firstItem).hasSize(5)
 
-            categorySelectionViewModel.selectAllThisCategory(emptyList())
+            categorySelectionViewModel.selectAllTheseCategories(emptyList())
         }
     }
 }


### PR DESCRIPTION
Rewrote `selectAllThisCategory()` on [CategorySelectionViewModel](https://github.com/nkuppan/expensemanager/blob/main/feature/category/src/main/kotlin/com/naveenapps/expensemanager/feature/category/selection/CategorySelectionViewModel.kt) to remove code redundancy.

**Local Variable `selectedCategories` will always be empty after calling `clearChanges()`**

        `viewModelScope.launch {
            clearChanges()
             //selectedCategories will always be empty after clearChanges() is called
            val selectedCategories = _selectedCategory.value.toMutableList()

            repeat(categories.size) {
                val category = categories[it]

             //selectedCategory will always evaluate to null as we are filtering an Empty List
                val selectedCategory = selectedCategories.firstOrNull {
                    category.id == it.id
                }

              //this check is redundant as selectedCategory is null
                if (selectedCategory == null) {
                    selectedCategories.add(category)
                }
            }`

**To remove the above redundancy, we should update `_selectedCategories` directly.

        
     `viewModelScope.launch {

            clearChanges()// clear the current list of selected categories

            _selectedCategories.value = categories //assign categories directly
        }`

**This function is now more efficient as it doesn't perform unnecessary checks or operations. It simply replaces the old selections with the new ones**